### PR TITLE
Add depr issue template & work flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Open edX Community Support
+    url: https://discuss.openedx.org/
+    about: Please ask all questions, suggest all enhancements, and report all bugs here.

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -1,0 +1,83 @@
+name: Deprecation (DEPR) Ticket
+description: Per OEP-21, use this template to begin the technology deprecation process.
+title: "[DEPR]: <Technology Name>"
+labels: ["DEPR"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Refer to [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html) for more detail on the deprecation and removal process. This ticket should only be used for proposing the removal of an Open edX technology.
+  - type: input
+    id: todays-date
+    attributes:
+      label: Proposal Date
+      description: The start date of this proposal (likely today)
+      placeholder: 29 February 2020
+    validations:
+      required: true
+  - type: input
+    id: accept-date
+    attributes:
+      label: Ticket Acceptance Date
+      description: When is the target date for getting this proposal accepted?
+      placeholder: 29 February 2020
+    validations:
+      required: true
+  - type: input
+    id: remove-date
+    attributes:
+      label: Technology Removal Date
+      description: When is the target date for getting this technology removed?
+      placeholder: 29 February 2020
+    validations:
+      required: true
+  - type: input
+    id: named-release-without
+    attributes:
+      label: First Open edX Named Release Without This Functionality
+      description: Named releases are generally CUT in early April and early October. Based on the above removal date, what named release would be the first without this code? Please reach out to the Build Test Release working group (#wg-build-test-release in Slack) if you're not sure.
+      placeholder: Dogwood
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: Explain, in a few sentences, why this technology should be removed - what's the usage pattern? What's wrong with keeping it around?
+    validations:
+      required: true
+  - type: textarea
+    id: removal
+    attributes:
+      label: Removal
+      description: Include a description with links to what exactly is being removed.
+    validations:
+      required: true
+  - type: textarea
+    id: replacement
+    attributes:
+      label: Replacement
+      description: Include a description with links to what this is being replaced by.
+    validations:
+      required: true
+  - type: textarea
+    id: deprecation
+    attributes:
+      label: Deprecation
+      description: If you plan to mark the code for deprecation, explain how.
+    validations:
+      required: false
+  - type: textarea
+    id: migration
+    attributes:
+      label: Migration
+      description: If automated migration will be needed, explain your migration plan.
+    validations:
+      required: false
+  - type: textarea
+    id: addl-info
+    attributes:
+      label: Additional Info
+      description: If there is any additional publicly sharable information or data from your earlier analysis, include that.
+    validations:
+      required: false

--- a/.github/workflows/add-depr-ticket-to-depr-board.yml
+++ b/.github/workflows/add-depr-ticket-to-depr-board.yml
@@ -1,0 +1,57 @@
+# This workflow runs when an issue is created. It checks if the issue
+# has the "DEPR" label, and if so, adds it to the DEPR board.
+# The "DEPR" label is auto-applied to all issues created using the
+# `depr-ticket` issue template.
+
+name: Add newly created DEPR issues to the DEPR project board
+on:
+  # This action is meant to be used from other actions.
+  # https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+  - workflow_call
+
+jobs:
+  track_pr:
+    runs-on: ubuntu-latest
+    steps:
+      # Generate a token from org-level GitHub App because projects (beta)
+      # are defined at the org level
+      - name: Generate token
+        if: contains(github.event.issue.labels.*.name, 'DEPR')
+        id: generate_token
+        uses: tibdex/github-app-token@36464acb844fc53b9b8b2401da68844f6b05ebb0
+        with:
+          app_id: ${{ secrets.GRAPHQL_AUTH_APP_ID }}
+          private_key: ${{ secrets.GRAPHQL_AUTH_APP_PEM }}
+
+      - name: Get DEPR project ID
+        if: contains(github.event.issue.labels.*.name, 'DEPR')
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          ORGANIZATION: openedx
+          PROJECT_NUMBER: 9
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add DEPR issue to project
+        if: contains(github.event.issue.labels.*.name, 'DEPR')
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id')"

--- a/workflow-templates/add-depr-ticket-to-depr-board.yml
+++ b/workflow-templates/add-depr-ticket-to-depr-board.yml
@@ -1,0 +1,12 @@
+# Run the workflow that adds DEPR labeled issues
+# to the org-wide DEPR project board
+
+name: Add newly created DEPR issues to the DEPR project board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  routeissue:
+    uses: openedx/.github/.github/workflows/add-depr-ticket-to-depr-board.yml@master


### PR DESCRIPTION
@feanil 

Note that the issue template will work for repos that haven't defined their own templates. Once a repo does have its own templates, they'll need to pull this one in explicitly.

You can see the template in action at https://github.com/openedx/tcril-onboarding/issues/new/choose and view the results of this action on the Actions tab. The most recent changes to the workflow were to explicitly test for the conditional on the `if` clause each time so no actions run if the ticket isn't DEPR. I tried using `if: ${{ success() }}` but for whatever reason, the first step is considered a success even if it doesn't run. Shrug.