### PR TITLE
fix: fix the reusable label issue workflow

### DIFF
--- a/.github/workflows/add-remove-label-on-comment.yml
+++ b/.github/workflows/add-remove-label-on-comment.yml
@@ -11,8 +11,9 @@
 name: Allows for adding and removing labels via comment
 
 on:
-  issue_comment:
-    types: [created]
+  # This action is meant to be used from other actions.
+  # https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+  - workflow_call
 
 jobs:
   add_label:


### PR DESCRIPTION
### Description
- Reusable workflows need to have an on: workflow_call trigger to make it possible for other workflows to use it.
- Currently triggering the reusable workflow by commenting from any other openedx repo fails with this error https://github.com/openedx/public-engineering/actions/runs/2567248995.
- Updated the workflow to include correct trigger condition.