### PR TITLE
fix: interpolation of default branches comes with quotes

### DIFF
--- a/workflow-templates/upgrade-python-requirements.yml
+++ b/workflow-templates/upgrade-python-requirements.yml
@@ -8,13 +8,16 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: '$default-branch'
+        # If copying this template manually, you must provide your default branch name
+        # in quotes, such as 'master'
+        default: $default-branch
 
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
-      branch: ${{ github.event.inputs.branch || '$default-branch' }}
+    # If copying manually, also provide your default branch name in quotes here
+      branch: ${{ github.event.inputs.branch || $default-branch }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""


### PR DESCRIPTION
so extra quotes here is unnecessary & in fact causes bugs!

see https://github.com/openedx/docs.openedx.org/pull/135#issuecomment-1251146158 for step-by-step explanation of what this fixes; after this PR you would expect the final screengrab to not have two sets of quotes nested within one another any more