### PR TITLE
fix: Update bash command to fix reusable workflow failure

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: echo "target_branch=$(if ['$BRANCH' = '']; then echo '$DEFAULT_BRANCH'; else echo '$BRANCH'; fi)" >> $GITHUB_ENV
+        run: echo "target_branch=$(if [ $BRANCH = '' ]; then echo $DEFAULT_BRANCH; else echo $BRANCH; fi)" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### Description
- After the new release of `checkout@v2.5.0` the requirements upgrade PR started failing in all repos.
- The error was able to be reproduced with replicating the if condition in a test [PR](https://github.com/openedx/edx-rest-api-client/pull/237). 

### Testing
- After fixing and testing the fix on local, now creating the PR to test this change in the upgrade requirements workflows by triggering a custom workflow build against the updated workflow.
- Since the PR has been created against a fork so this commit hash or branch name can't be used in any workflow that's why we need to merge the change to test it properly in other requirements upgrade actions.