### PR TITLE
chore: upgrade depr workflow tibdex dependency

### DIFF
--- a/.github/workflows/add-depr-ticket-to-depr-board.yml
+++ b/.github/workflows/add-depr-ticket-to-depr-board.yml
@@ -46,7 +46,7 @@ jobs:
       # are defined at the org level
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@36464acb844fc53b9b8b2401da68844f6b05ebb0
+        uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.GITHUB_APP_ID }}
           private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Upgrade tibdex dependency to pull in the node 16 upgrade, as Actions are deprecating node 12. Tested and working for the BTR workflow: https://github.com/orgs/openedx/projects/28