### PR TITLE
fix: Default branch fallback

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: echo "target_branch=$(if [ $BRANCH = '' ]; then echo $DEFAULT_BRANCH; else echo $BRANCH; fi)" >> $GITHUB_ENV
+        run: echo "target_branch=${BRANCH:-${DEFAULT_BRANCH}}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Use bash parameter expansion[1] for the DEFAULT_BRANCH fallback.  This should avoid other syntax gotchas once and for all.

[1] https://wiki.bash-hackers.org/syntax/pe#use_a_default_value

[This comment](https://github.com/openedx/.github/pull/33/files#r1032074481) links to [the failure](https://github.com/edx/edx-e2e-tests/actions/runs/3544876433/jobs/5952541056#step:2:2) this intends to fix.