### PR TITLE
fix: added required secret in workflow

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -1,6 +1,9 @@
 name: Update Browserslist DB
 on:
-  - workflow_call
+  workflow_call
+    secrets:
+      requirements_bot_github_token:
+        required: true
 
 jobs:
   update-dep:

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -1,6 +1,6 @@
 name: Update Browserslist DB
 on:
-  workflow_call
+  workflow_call:
     secrets:
       requirements_bot_github_token:
         required: true

--- a/workflow-templates/update-browserslist-db.properties.json
+++ b/workflow-templates/update-browserslist-db.properties.json
@@ -1,0 +1,7 @@
+{
+    "name": "Auto Update Browserslist DB Workflow",
+    "description": "Run weekly to create a PR that updates browserslist DB",
+    "iconName": "edx-workflow-template-icon",
+    "categories": [],
+    "filePatterns": []
+}

--- a/workflow-templates/update-browserslist-db.yml
+++ b/workflow-templates/update-browserslist-db.yml
@@ -9,3 +9,5 @@ on:
 jobs:
   update-browserslist:
     uses: openedx/.github/.github/workflows/update-browserslist-db.yml@master
+    secrets:
+      requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}

--- a/workflow-templates/update-browserslist.properties-db.json
+++ b/workflow-templates/update-browserslist.properties-db.json
@@ -1,7 +1,0 @@
-{
-    "name": "Auto Update Browserslist DB Workflow",
-    "description": "Run weekly to create a PR that updates browserslist DB",
-    "iconName": "edx-workflow-template-icon",
-    "categories": [],
-    "filePatterns": []
-}


### PR DESCRIPTION
This PR fixes the issues of consumers of this workflow [crashing](https://github.com/openedx/frontend-app-account/actions/runs/3731200392) because secrets were not [provided](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets)