### PR TITLE
docs: add warning to blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -1,6 +1,6 @@
 ---
-name: 📝 Blank Issue
-about: Submit an issue relating to this repository
+name: 📝 Blank Issue (Reponse not guaranteed!)
+about: Record an established issue relating to this repository. In order to increase the likelihood of getting a reponse, we highly recommend cross-posting the issue to the community forum (linked below).
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
We would like to get to a place where every repo has a maintainer that triages incoming issues. Although the maintainership pilot [1] is chugging along, we are not there yet.

So, in the meantime, issue submitters should be warned that they may not get a response unless they cross-post to the forums.

[1] https://openedx.atlassian.net/wiki/spaces/COMM/pages/3426844690/Maintainership+Pilot
