### PR TITLE
feat: Auto make PRs to update versions of dependent github actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+
 version: 2
 updates:
 


### PR DESCRIPTION
Our github actions build on top of various ones from the community but
we don't have a mechanism for updating those yet.  Use the built-in
capabilities of dependabot to create PRs in this repo for updates to our
action dependencies.
