### PR TITLE
fix: Job IDs can't have spaces.

### DIFF
--- a/workflow-templates/add-new-issues-to-a-project.yml
+++ b/workflow-templates/add-new-issues-to-a-project.yml
@@ -10,7 +10,7 @@ on:
     types: [opened]
 
 jobs:
-  Add an issue to project:
+  Add_an_issue_to_project:
     uses: openedx/.github/.github/workflows/add-issue-to-a-project.yml@master
     secrets:
       GITHUB_APP_ID: ${{ secrets.GRAPHQL_AUTH_APP_ID }}

--- a/workflow-templates/add-new-issues-to-a-project.yml
+++ b/workflow-templates/add-new-issues-to-a-project.yml
@@ -10,7 +10,7 @@ on:
     types: [opened]
 
 jobs:
-  Add_an_issue_to_project:
+  add_an_issue_to_project:
     uses: openedx/.github/.github/workflows/add-issue-to-a-project.yml@master
     secrets:
       GITHUB_APP_ID: ${{ secrets.GRAPHQL_AUTH_APP_ID }}


### PR DESCRIPTION
Update the template to not have any spaces in the job name.
