### PR TITLE
feat: Added workflow for lockfileVersion 3 check

### DIFF
--- a/.github/workflows/lockfileversion-check-v3.yml
+++ b/.github/workflows/lockfileversion-check-v3.yml
@@ -1,5 +1,9 @@
 #check package-lock file version
 
+# With move to Node.js v18 and NPM 9, the resulting lockfileVersion is updated to 3.
+# This is a workflow to verify the use of NPM 9 and lockfileVersion 3
+# and intends to phase out the older workflow checking for lockfileVersion 2.
+
 name: lockfileVersion check v3
 
 on:

--- a/.github/workflows/lockfileversion-check-v3.yml
+++ b/.github/workflows/lockfileversion-check-v3.yml
@@ -1,0 +1,26 @@
+#check package-lock file version
+
+name: lockfileVersion check v3
+
+on:
+  - workflow_call
+
+jobs:
+  version-check:
+    runs-on:  ubuntu-20.04
+    outputs:
+      output1: ${{ steps.getversion.outputs.version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Retrieve version
+      id: getversion
+      run: |
+        echo "::set-output name=version::$(cat package-lock.json | grep '\"lockfileVersion\": 3,')"
+
+    - name: check value
+      if: ${{ steps.getversion.outputs.version == null }}
+      run: |
+        echo "ERROR: Outdated package-lock file. Use NPM9 to install dependencies "
+        exit 1

--- a/.github/workflows/lockfileversion-check-v3.yml
+++ b/.github/workflows/lockfileversion-check-v3.yml
@@ -11,20 +11,20 @@ on:
 
 jobs:
   version-check:
-    runs-on:  ubuntu-20.04
-    outputs:
-      output1: ${{ steps.getversion.outputs.version }}
+    runs-on: ubuntu-20.04
+    env:
+      VERSION: ${{ steps.getversion.outputs.version }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Retrieve version
-      id: getversion
-      run: |
-        echo "::set-output name=version::$(cat package-lock.json | grep '\"lockfileVersion\": 3,')"
+      - name: Retrieve version
+        id: getversion
+        run: |
+          echo "::set-output name=version::$(cat package-lock.json | grep '\"lockfileVersion\": 3,')"
 
-    - name: check value
-      if: ${{ steps.getversion.outputs.version == null }}
-      run: |
-        echo "ERROR: Outdated package-lock file. Use NPM9 to install dependencies "
-        exit 1
+      - name: Check value
+        if: env.VERSION == null
+        run: |
+          echo "ERROR: Outdated package-lock file. Use NPM9 to install dependencies "
+          exit 1

--- a/workflow-templates/lockfileversion-check-v3.properties.json
+++ b/workflow-templates/lockfileversion-check-v3.properties.json
@@ -1,0 +1,7 @@
+{
+     "name": "LockfileVersion v3 Workflow",
+     "description": "Verify lockfileVersion is 3 in package-lock.json",
+     "iconName": "edx-workflow-template-icon",
+     "categories": [],
+     "filePatterns": []
+ }

--- a/workflow-templates/lockfileversion-check-v3.yml
+++ b/workflow-templates/lockfileversion-check-v3.yml
@@ -1,0 +1,13 @@
+#check package-lock file version
+
+name: lockfileVersion check
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  version-check:
+    uses: openedx/.github/.github/workflows/lockfileversion-check-v3.yml@master


### PR DESCRIPTION
With move to node v18 and NPM9, the `lockfileVersion` is set to 3. Added a workflow to verify NPM9 is used to generate `package-lock` file by ensuring `lockfileVersion` is set to 3. Once node upgrade to v18 is complete across all MFEs, older version of the workflow which is checking for `lockVersion` 2 can be phased out.