### PR TITLE
fix: fix repo health workflow secrets syntax

### DIFF
--- a/.github/workflows/repo-health-job.yml
+++ b/.github/workflows/repo-health-job.yml
@@ -12,11 +12,9 @@ on:
       REPO_HEALTH_GOOGLE_CREDS_FILE:
         description: "Link to the repo health credentials file"
         required: true
-        default: ""
       READTHEDOCS_API_KEY:
         description: "API Key for READ THE DOCS Access"
         required: true
-        default: ""
 
     inputs:
       ORG_NAMES:


### PR DESCRIPTION
### Description
- Workflow trigger failed with following error because of syntax issues in the reusable workflow file. 
```
[Invalid workflow file: 
.github/workflows/repo-health-job.yml#L35](https://github.com/edx/repo-health-data/actions/runs/4609308058/workflow)
The workflow is not valid. In .github/workflows/repo-health-job.yml (Line: 35, Col: 11): Error from called workflow 
openedx/.github/.github/workflows/repo-health-job.yml@master (Line: 15, Col: 9): Unexpected value 'default' 
openedx/.github/.github/workflows/repo-health-job.yml@master (Line: 19, Col: 9): Unexpected value 'default'
```
- Removed the `default` parameter from secrets syntax.
- It is not possible to test the reusable workflow changes without first merging the changes so creating fix PRs bit by bit as `arbi-bom` faces errors when trying to execute the workflow.
