### PR TITLE
fix: update repo health workflow parameter type

### DIFF
--- a/.github/workflows/repo-health-job.yml
+++ b/.github/workflows/repo-health-job.yml
@@ -39,8 +39,8 @@ on:
         default: ""
       REPO_HEALTH_REPOS_WORKSHEET_ID:
         description: "Repo health repositories sheet ID"
-        type: number
-        default: 0
+        type: string
+        default: "0"
       TARGET_REPO_TO_STORE_REPORTS:
         description: "Target repo to store the csv reports & results i.e. org/repo-name"
         type: string


### PR DESCRIPTION
### Description
- We want the input values to be all in strings so it'll be easier to pass these through the GITHUB Variables and Context variables to the reusable workflow.
- The string input parameter will be typecasted to number later on within the bash script if needed. 