### PR TITLE
fix: update depr-ticket.yml named releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Proposal Date
       description: The start date of this proposal (likely today)
-      placeholder: 29 February 2020
+      placeholder: 2020-02-29
     validations:
       required: true
   - type: input
@@ -21,15 +21,15 @@ body:
     attributes:
       label: Target Ticket Acceptance Date
       description: When is the target date for getting this proposal reviewed and accepted? A good default is approximately 2 weeks from when the ticket is communicated (see [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html)).
-      placeholder: 29 February 2020
+      placeholder: 2020-03-14
     validations:
       required: true
   - type: input
     id: named-release-without
     attributes:
       label: Earliest Open edX Named Release Without This Functionality
-      description: What is the earliest named release without this code? Named releases are generally CUT in early April and early October. Use "Olive - 2022-10", or "Palm - 2023-04", or "Q - 2023-10" as examples. Please reach out to the Build Test Release working group (#wg-build-test-release in Slack) if you're not sure.
-      placeholder: Olive - 2022-10
+      description: What is the earliest named release without this code? Named releases are generally CUT in early April and early October. Use "Quince - 2023-10", or "Redwood - 2024-04", or "S - 2024-10" as examples. Please reach out to the Build Test Release working group (#wg-build-test-release in Slack) if you're not sure.
+      placeholder: Quince - 2023-10
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Update the named releases on the DEPR issue template, and update the default date format to be more standard.