### PR TITLE
docs: minor rewording of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-# Welcome to the Open edX Platform Contributing Guide
+# Contributing to the Open edX project
 
-Thank you for your interest in contributing to the Open edX Project,  you can find our [most up-to-date contributing
-guidelines](https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+start+contributing+to+the+Open+edX+code+base)
-on our [wiki](https://openedx.atlassian.net/wiki).
+Thank you for your interest in contributing to the Open edX project!
+
+You can find our [latest contribution guidelines on the community wiki](https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+start+contributing+to+the+Open+edX+code+base).


### PR DESCRIPTION
* splits up a run-on sentence
* removes link to wiki homepage, which I've accidentally clicked a few times now instead of clicking the link to the contribution guidelines