### PR TITLE
docs: update security.md policy to reflect Open edX policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,18 @@
 # Open edX Security Policy
 
-If you have any questions or concerns relating to the security of Open edX code (including any potential vulnerability disclosures), please follow the guidance in the [edX security policy](https://www.edx.org/policy/security). edX's security team will be happy to assist you.
+## Disclosing a Security Vulnerability
+If you believe that you have discovered a security vulnerability or other suspicious activity relating to the Open edX platform code base, please:
+* report it to the Open edX project by emailing the Open edX Security Working Group at security@openedx.org;
+* describe the nature of the vulnerability; and
+* provide sufficient detail in your report to enable the Open edX Security Working Group to respond quickly reproduce and understand the vulnerability and respond effectively, including the following (as applicable):
+    * a textual description of the steps necessary to reproduce the issue;
+    * proof-of-concept code; and
+    * links to vulnerable code.
 
-In the future, the Open edX project will develop an independent security policy and process.
+Upon receipt of your email, the Open edX Security Group will acknowledge the receipt of your email, review and triage your security vulnerability, and act accordingly. If necessary, the group will reach out to you for more information. The group will not provide communication on the status of the security vulnerability after it has been reviewed and triaged.
+
+## Bug Bounty
+The Open edX project does not offer bug bounties for security vulnerability disclosures.
+
+## Out of Scope
+There are many sites powered by the Open edX platform. If you have found a vulnerability that is specific to an Open edX deployment please contact the operators of that site directly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ If you believe that you have discovered a security vulnerability or other suspic
     * proof-of-concept code; and
     * links to vulnerable code.
 
-Upon receipt of your email, the Open edX Security Group will acknowledge the receipt of your email, review and triage your security vulnerability, and act accordingly. If necessary, the group will reach out to you for more information. The group will not provide communication on the status of the security vulnerability after it has been reviewed and triaged.
+Upon receipt of your email, the Open edX Security Working Group will acknowledge the receipt of your email, review and triage your security vulnerability, and act accordingly. If necessary, the group will reach out to you for more information. The group will not provide communication on the status of the security vulnerability after it has been reviewed and triaged.
 
 ## Bug Bounty
 The Open edX project does not offer bug bounties for security vulnerability disclosures.


### PR DESCRIPTION
With the acceptance of [OEP-60](https://github.com/openedx/open-edx-proposals/blob/master/oeps/processes/oep-0060-proc-sec-group.rst), the security policy should accurately reflect the separation of security processes between the Open edX community and edX. 

The new security policy is specific to the Open edX process, and includes an updated email address for reporting security vulnerabilities. 