### PR TITLE
build: fix script download path for reusable workflow

### DIFF
--- a/.github/workflows/merge-python-requirements-upgrade-prs.yml
+++ b/.github/workflows/merge-python-requirements-upgrade-prs.yml
@@ -47,11 +47,11 @@ jobs:
 
       - name: Download script file
         # Only download the script file if the repository is not openedx/.github
-        # Because, we were not able to download correclty outside of openedx due to calling reusable workflow call
+        # Because, we were not able to download correctly outside of openedx due to calling reusable workflow call
         if: ${{ github.repository != 'openedx/.github' }}
         run: |
           mkdir -p scripts
-          curl -o scripts/get_ready_to_merge_prs.py https://raw.githubusercontent.com/${{ github.repository }}/master/scripts/get_ready_to_merge_prs.py
+          curl -o scripts/get_ready_to_merge_prs.py https://raw.githubusercontent.com/openedx/.github/master/scripts/get_ready_to_merge_prs.py
 
       - name: Get urls of all eligible prs
         env:


### PR DESCRIPTION
## Description
- The reusable workflow was added in the https://github.com/openedx/.github/pull/77
- The workflow triggering [fails](https://github.com/edx/.github/actions/runs/5045122890) when being called from `edx` organisation due to the wrong file path issue.
- The custom parameter `github.repository` in the script path [changes](https://github.com/edx/.github/actions/runs/5045122890/jobs/9048997498#step:5:3) the file path to `edx` in our case whereas the correct path should always be `openedx/.github` instead.

## Fix
- Updated the script download step to always download the script from the `openedx/.github` repo where it originally resides.