### PR TITLE
feat: Stop using deprecated ::set-output in commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -21,17 +21,12 @@ jobs:
           # Fetch 100 commits.  Should be enough?
           fetch-depth: 100
 
-      - name: Check for a local configuration file
-        id: check
+      - name: Download a local configuration file if needed
         run: |
           if [[ ! -f commitlint.config.js ]]; then
-            echo "::set-output name=need::yes"
+            echo "Downloading the default commitlint config from edx_lint"
+            wget --no-verbose -O commitlint.config.js https://raw.githubusercontent.com/openedx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
           fi
-
-      - name: Download configuration if needed
-        if: steps.check.outputs.need == 'yes'
-        run: |
-          wget --no-verbose -O commitlint.config.js https://raw.githubusercontent.com/openedx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
 
       - name: Run commitlint
         uses: wagoid/commitlint-github-action@v5


### PR DESCRIPTION
GitHub is going to stop supporting this insecure approach at some undefined future date:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I don't think there's much benefit in keeping this separated as two steps, so instead of using `GITHUB_OUTPUT` we can just make it a single step.