### PR TITLE
feat: Update the npm publish workflow template.

### DIFF
--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -3,19 +3,20 @@ on:
   push:
     branches:
       - master
+      - main
 jobs:
   release:
     name: Release
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -26,6 +27,6 @@ jobs:
         run: npm run build
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENEDX_NPM_RELEASE_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.OPENEDX_NPM_RELEASE_NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
This will default any new packages that try to publish to a set of
tokens that can publish to the `openedx` scope.  It also updates the
template to use the version of Node from `.nvmrc` instead of hardcoding
to Node 12
