### PR TITLE
fix: Update npm release workflow template.

### DIFF
--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -27,6 +27,6 @@ jobs:
         run: npm run build
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENEDX_NPM_RELEASE_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.OPENEDX_NPM_RELEASE_NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
We changed the names for the secrets to be more generic than NPM because
they are being used for semantic release of other libraries to other
package systems as well.
