### PR TITLE
fix: commitlint fails if run in a repo that uses ES6 modules

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,9 +23,9 @@ jobs:
 
       - name: Download a local configuration file if needed
         run: |
-          if [[ ! -f commitlint.config.js ]]; then
+          if [[ ! -f commitlint.config.js ]] && [[ ! -f commitlint.config.cjs ]]; then
             echo "Downloading the default commitlint config from edx_lint"
-            wget --no-verbose -O commitlint.config.js https://raw.githubusercontent.com/openedx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
+            wget --no-verbose -O commitlint.config.cjs https://raw.githubusercontent.com/openedx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
           fi
 
       - name: Run commitlint


### PR DESCRIPTION
On a recent PR of mine, [the commitlint check was failing](https://github.com/openedx/frontend-platform/actions/runs/7254831382/job/19764334943?pr=619) because of an error in the workflow:

```
error running commitlint
require() of ES Module /github/workspace/commitlint.config.js from /node_modules/@commitlint/load/node_modules/cosmiconfig/dist/loaders.js not supported.
commitlint.config.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename commitlint.config.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /github/workspace/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

The reason is that I am changing the repo to use ES6 modules, by putting `"type": "module"` in `package.json`. This is the newer, modern format for JavaScript source files. However, commitlint requires that its config file use the older CommonJS format.

As you can read in [this commitlint issue](https://github.com/conventional-changelog/commitlint/issues/902), the simple workaround for now is to rename the config file to use the `.cjs` extension. This is a painless fix that is perfectly backwards compatible, and now the commitlint check will work regardless of the current repo's `module` setting.

See an [example showing a successful commitlint check](https://github.com/openedx/frontend-platform/actions/runs/7256123844/job/19767909351?pr=619) in the same repo after I [temporarily incorporated this fix](https://github.com/openedx/frontend-platform/pull/619/commits/066be1ebf27db518dbbba963fe804280a12b001e).

(Another way to fix this would be to `rm package.json` before running commitlint, so that its runtime environment is not influenced by the checked-out repo's `package.json` settings, but that seems unnecessary.)