### PR TITLE
chore: stop sending notification for update python requirements on unchanged

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -105,7 +105,7 @@ jobs:
           body: Upgrade python requirements workflow in ${{github.repository}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Send success notification
-        if: ${{ inputs.send_success_notification && inputs.email_address }}
+        if: ${{ inputs.send_success_notification && inputs.email_address && steps.createpullrequest.outputs.generated_pr }}
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: email-smtp.us-east-1.amazonaws.com


### PR DESCRIPTION
Description:
- This is to stop the workflow to send notification on requirement unchanged.

Note:
If we want to have specific output for this case, we can add additional output on https://github.com/openedx/testeng-ci/blob/ed9083cd6f0a774d5de75cefd356ad69dd47b9bf/jenkins/pull_request_creator.py#L224. However, I think this should be enough.