### PR TITLE
docs: change tutor language

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,7 @@ If you're trying to learn more, check out...
 * the homepage: [openedx.org](https://openedx.org),
 * the discussion forums: [discuss.openedx.org](https://discuss.openedx.org/),
 * the main LMS and CMS application repository: [edx-platform](https://github.com/edx/edx-platform),
-* the official installation method (also a development tool!): [tutor](https://docs.tutor.overhang.io/).
+* the community-supported installation method (also a development tool!): [tutor](https://docs.tutor.overhang.io/).
 
 Although Open edX software is built by many developers across different organizations,
 the GitHub organization itself is administered by [Axim Collaborative](https://axim.org).


### PR DESCRIPTION
This edits the blurb on our [GH homepage](https://github.com/openedx/).

Tutor is definitely the community-supported distribution, but we're not cleared to describe it as "official".

(FWIW I originally wrote this, way back before I realized that)