### PR TITLE
Revert "build(deps): bump wagoid/commitlint-github-action from 5 to 6"

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -29,4 +29,4 @@ jobs:
           fi
 
       - name: Run commitlint
-        uses: wagoid/commitlint-github-action@v6
+        uses: wagoid/commitlint-github-action@v5


### PR DESCRIPTION
Reverts openedx/.github#124

Reverting this, because it seems to be causing some issues, https://github.com/openedx/edx-lint/actions/runs/8604287415/job/23578582410

We can re-introduce it when we have more time to test/debug what's going on here.