### PR TITLE
build: Update workflow template for PyPI Publishing.

### DIFF
--- a/workflow-templates/pypi-publish.yml
+++ b/workflow-templates/pypi-publish.yml
@@ -2,7 +2,7 @@ name: Publish package to PyPI
 
 on:
   push:
-    tags: 
+    tags:
       - '*'
 
 jobs:
@@ -24,7 +24,6 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
The action now publishes versions and the master branch will stop
getting updates.  Also `__token__` is the default username so no need to
set it explicitly.
