### PR TITLE
build: update requirements upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -62,6 +62,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
+      
+      - name: setup dev for lxml dependency
+        run: |
+          sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev
 
       - name: make upgrade
         run: |

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -62,7 +62,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
-      
+      # With the updated package lxml>5.0, now the system dev packages are necessary 
+      # to run pip-compile. Without installing dev packages libxml2-dev and libxslt-dev, 
+      # the requirements upgrade job fails
       - name: setup dev for lxml dependency
         run: |
           sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev


### PR DESCRIPTION
## Description
- With the updated package `lxml>5.0`, now the system dev packages are necessary to run `pip-compile`. Without installing dev packages `libxml2-dev` and `libxslt-dev`, the `requirements upgrade job` fails with following stack trace: 
See example failure build [error stack trace](https://github.com/openedx/edx-platform/actions/runs/8883842771/job/24391571930#step:5:433).
```
  Collecting lxml (from -r requirements/edx-sandbox/base.in (line 5))
    Downloading lxml-5.2.1.tar.gz (3.7 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.7/3.7 MB 11.3 MB/s eta 0:00:00
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error
    
    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [4 lines of output]
        <string>:67: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
        Building lxml version 5.2.1.
        Building without Cython.
        Error: Please make sure the libxml2 and libxslt development packages are installed.
        [end of output]
```

## Solution
- The requirements upgrade workflow has been updated to install system dev packages before running `make upgrade` to resolve the issue similar to the method opted in the platform upgrade [PR](https://github.com/openedx/edx-platform/pull/34655). 