### PR TITLE
feat: use pull request creator from repo-tools, not testeng-ci

### DIFF
--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -112,9 +112,7 @@ jobs:
 
       - name: setup pull_request_creator
         run: |
-          git clone https://github.com/openedx/repo-tools.git
-          cd $GITHUB_WORKSPACE/repo-tools
-          pip install -e '.[pull_request_creator]'
+          pip install 'edx-repo-tools[pull_request_creator]'
 
       - name: setup draft flag
         run: echo "draftflag=$(if ${{ github.event.inputs.draft }}; then echo '--draft'; else echo ''; fi)" >> $GITHUB_ENV
@@ -130,7 +128,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}
           GITHUB_USER_EMAIL: ${{ secrets.requirements_bot_github_email }}
         run: |
-          cd $GITHUB_WORKSPACE/repo-tools
           pull_request_creator --repo-root=$GITHUB_WORKSPACE \
           --target-branch="${{ env.BRANCH }}" --base-branch-name="${{ github.event.inputs.branch }}" \
           --commit-message="${{ github.event.inputs.commit_message }}" \

--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ github.event.inputs.python_version }}
-          
+
       - name: Setup Nodejs
         uses: actions/setup-node@v4
         with:
@@ -110,11 +110,11 @@ jobs:
       - name: run script
         run: ${{ github.event.inputs.script }}
 
-      - name: setup testeng-ci
+      - name: setup pull_request_creator
         run: |
-          git clone https://github.com/edx/testeng-ci.git
-          cd $GITHUB_WORKSPACE/testeng-ci
-          pip install -r requirements/base.txt
+          git clone https://github.com/openedx/repo-tools.git
+          cd $GITHUB_WORKSPACE/repo-tools
+          pip install -e '.[pull_request_creator]'
 
       - name: setup draft flag
         run: echo "draftflag=$(if ${{ github.event.inputs.draft }}; then echo '--draft'; else echo ''; fi)" >> $GITHUB_ENV
@@ -122,16 +122,16 @@ jobs:
       - name: setup force delete flag
         run: echo "force_delete_old_prs_flag=$(if ${{ github.event.inputs.force_delete_old_prs }}; then echo '--force-delete-old-prs'; else echo '--no-force-delete-old-prs'; fi)" >> $GITHUB_ENV
 
-      - name: ignore testeng-ci
-        run: echo "testeng-ci" >> .git/info/exclude
+      - name: ignore repo-tools
+        run: echo "repo-tools" >> .git/info/exclude
 
       - name: create pull request
         env:
           GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}
           GITHUB_USER_EMAIL: ${{ secrets.requirements_bot_github_email }}
         run: |
-          cd $GITHUB_WORKSPACE/testeng-ci
-          python -m jenkins.pull_request_creator --repo-root=$GITHUB_WORKSPACE \
+          cd $GITHUB_WORKSPACE/repo-tools
+          pull_request_creator --repo-root=$GITHUB_WORKSPACE \
           --target-branch="${{ env.BRANCH }}" --base-branch-name="${{ github.event.inputs.branch }}" \
           --commit-message="${{ github.event.inputs.commit_message }}" \
           --pr-title="${{ github.event.inputs.commit_message }}"  \

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -74,11 +74,12 @@ jobs:
           cd $GITHUB_WORKSPACE
           make upgrade
 
-      - name: setup testeng-ci
+      - name: setup pull_request_creator
         run: |
-          git clone https://github.com/edx/testeng-ci.git
-          cd $GITHUB_WORKSPACE/testeng-ci
-          pip install -r requirements/base.txt
+          git clone https://github.com/openedx/repo-tools
+          cd $GITHUB_WORKSPACE/repo-tools
+          pip install -e '.[pull_request_creator]'
+
       - name: create pull request
         id: createpullrequest
         env:
@@ -88,10 +89,11 @@ jobs:
           USER_REVIEWERS: ${{ inputs.user_reviewers }}
           TEAM_REVIEWERS: ${{ inputs.team_reviewers }}
         run: |
-          cd $GITHUB_WORKSPACE/testeng-ci
-          python -m jenkins.pull_request_creator --repo-root=$GITHUB_WORKSPACE \
+          cd $GITHUB_WORKSPACE/repo-tools
+          pull_request_creator --repo-root=$GITHUB_WORKSPACE \
           --target-branch="$TARGET_BRANCH" --base-branch-name="upgrade-python-requirements" \
-          --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
+          --commit-message="chore: Upgrade Python requirements" \
+          --pr-title="chore: Upgrade Python requirements" \
           --pr-body="Python requirements update. Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
           --user-reviewers="$USER_REVIEWERS" \
           --team-reviewers="$TEAM_REVIEWERS" \

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -89,7 +89,6 @@ jobs:
           USER_REVIEWERS: ${{ inputs.user_reviewers }}
           TEAM_REVIEWERS: ${{ inputs.team_reviewers }}
         run: |
-          cd $GITHUB_WORKSPACE/repo-tools
           pull_request_creator --repo-root=$GITHUB_WORKSPACE \
           --target-branch="$TARGET_BRANCH" --base-branch-name="upgrade-python-requirements" \
           --commit-message="chore: Upgrade Python requirements" \

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -76,9 +76,7 @@ jobs:
 
       - name: setup pull_request_creator
         run: |
-          git clone https://github.com/openedx/repo-tools
-          cd $GITHUB_WORKSPACE/repo-tools
-          pip install -e '.[pull_request_creator]'
+          pip install 'edx-repo-tools[pull_request_creator]'
 
       - name: create pull request
         id: createpullrequest


### PR DESCRIPTION
## Description

testeng-ci is deprecated in favor of repo-tools.
See the DEPR [1] and the PR that moved pull_request_creator to repo-tools [2].

This also includes some cosmetic changes to the upgrade PRs.

Before:
* branch == jenkins/upgrade-python-requirements-{id}
* title  == Python Requirements Update
* commit == chore: Updating Python Requirements

After:
* branch == repo-tools/upgrade-python-requirements-{id}
* title  == chore: Upgrade Python requirements
* commit == chore: Upgrade Python requirements

NOTE: This leaves behind a testeng-ci reference in the repo-health job. We need to figure out the future of the edx-repo-health repo. This will be a future task [3]

[1] https://github.com/openedx/public-engineering/issues/265
[2] https://github.com/openedx/repo-tools/pull/517
[3] https://github.com/openedx/.github/issues/138

## Testing

I tested this on the XBlock repo:

* Job: https://github.com/openedx/XBlock/actions/runs/9390464305/job/25860392873
* Generated PR: https://github.com/openedx/XBlock/pull/757