### PR TITLE
perf: added workflow to comment next version on PR raise trigger

### DIFF
--- a/.github/workflows/expected-release-version.yml
+++ b/.github/workflows/expected-release-version.yml
@@ -12,9 +12,7 @@ jobs:
       release_level: ${{ steps.release_type.outputs.RELEASE_TYPE }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ env.GITHUB_SHA }}
+        uses: actions/checkout@v4
       - name: Get Commit Messages
         id: get_commit_messages
         run: |
@@ -43,9 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ env.GITHUB_SHA }}
+        uses: actions/checkout@v4
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
@@ -76,14 +72,14 @@ jobs:
         id: list-comments
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          COMMENTS=$(curl -s -H "Accept: application/vnd.github.v3+json" \
+          COMMENTS=$(curl -s -H "Accept: application/vnd.github+json" \
                         -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                         "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments")
           echo "$COMMENTS" > comments.json
 
       - name: Identify and delete previous comment
         run: |
-          COMMENT_IDS=$(jq -r '.[] | select(.user.login=="github-actions[bot]") | .id' comments.json)
+          COMMENT_IDS=$(jq -r '.[] | select(.body=="Merging this PR will generate the new tag version ${{ steps.get-latest-tag.outputs.tag }}") | .id' comments.json)
           for COMMENT_ID in $COMMENT_IDS; do
             echo "Deleting comment ID $COMMENT_ID"
             curl -s -X DELETE -H "Accept: application/vnd.github.v3+json" \
@@ -91,12 +87,12 @@ jobs:
                 "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID"
           done
       - name: Script to comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '🎉 This PR is included in version ${{ steps.next_version.outputs.NEXT_TAG }} 🎉 '
+              body: 'Merging this PR will generate the new tag version ${{ steps.next_version.outputs.NEXT_TAG }}'
             })

--- a/.github/workflows/expected-release-version.yml
+++ b/.github/workflows/expected-release-version.yml
@@ -50,10 +50,12 @@ jobs:
         run: |
           echo ${{ steps.get-latest-tag.outputs.tag }}
           IFS='v' read -r -a VERSION <<< "${{ steps.get-latest-tag.outputs.tag }}"
-          if [ VERSION[1] == null ]: then
-            IFS='.' read -r -a VERSION_PARTS <<< "${VERSION[0]}"
-          elif [ VERSION[1] != null ]: then
+          
+          # Check if the tag starts with "v" and has a version part
+          if [ "${#VERSION[@]}" -eq 2 ]; then
             IFS='.' read -r -a VERSION_PARTS <<< "${VERSION[1]}"
+          else
+            IFS='.' read -r -a VERSION_PARTS <<< "${VERSION[0]}"
           fi
           MAJOR=${VERSION_PARTS[0]}
           MINOR=${VERSION_PARTS[1]}

--- a/.github/workflows/expected-release-version.yml
+++ b/.github/workflows/expected-release-version.yml
@@ -1,0 +1,102 @@
+# add comment on PR for expected release version based on the commit messages
+
+name: Expected Release Version
+on:
+  - workflow_call
+
+jobs:
+  release-type:
+    name: Check Release Type
+    runs-on: ubuntu-latest
+    outputs:
+      release_level: ${{ steps.release_type.outputs.RELEASE_TYPE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.GITHUB_SHA }}
+      - name: Get Commit Messages
+        id: get_commit_messages
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMITS=$(curl -s -H "Accept: application/vnd.github.v3+json" \
+                          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                          "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/commits")
+          COMBINED_MESSAGES=$(echo "$COMMITS" | jq -r '.[].commit.message' | paste -sd ' ')
+          echo "COMBINED_MESSAGES=$COMBINED_MESSAGES" >> $GITHUB_OUTPUT
+      - name: Get Release Type
+        id: release_type
+        run: |
+          if echo "${{ steps.get_commit_messages.outputs.COMBINED_MESSAGES }}" | grep -q "BREAKING CHANGE"; then
+            echo "RELEASE_TYPE=major" >> $GITHUB_OUTPUT
+          elif echo "${{ steps.get_commit_messages.outputs.COMBINED_MESSAGES }}" | grep -q "feat"; then
+            echo "RELEASE_TYPE=minor" >> $GITHUB_OUTPUT
+          elif echo "${{ steps.get_commit_messages.outputs.COMBINED_MESSAGES }}" | grep -q "fix"; then
+            echo "RELEASE_TYPE=patch" >> $GITHUB_OUTPUT
+          else
+            echo "RELEASE_TYPE=none" >> $GITHUB_OUTPUT
+          fi
+  determine-next-version:
+    name: Determine Next Version
+    needs: [release-type]
+    if: needs.release-type.outputs.release_level != 'none'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.GITHUB_SHA }}
+      - name: Get latest tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+      - name: Determine Next Version
+        id: next_version
+        run: |
+          echo ${{ steps.get-latest-tag.outputs.tag }}
+          IFS='v' read -r -a VERSION <<< "${{ steps.get-latest-tag.outputs.tag }}"
+          IFS='.' read -r -a VERSION_PARTS <<< "${VERSION[1]}"
+          MAJOR=${VERSION_PARTS[0]}
+          MINOR=${VERSION_PARTS[1]}
+          PATCH=${VERSION_PARTS[2]}
+
+          if [ "${{ needs.release-type.outputs.release_level }}" = "major" ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=$MINOR
+            PATCH=$PATCH
+          elif [ "${{ needs.release-type.outputs.release_level }}" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=$PATCH
+          elif [ "${{ needs.release-type.outputs.release_level }}" = "patch" ]; then
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEXT_TAG="v$MAJOR.$MINOR.$PATCH"
+          echo "NEXT_TAG=$NEXT_TAG" >> $GITHUB_OUTPUT
+      - name: List PR comments
+        id: list-comments
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMENTS=$(curl -s -H "Accept: application/vnd.github.v3+json" \
+                        -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                        "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments")
+          echo "$COMMENTS" > comments.json
+
+      - name: Identify and delete previous comment
+        run: |
+          COMMENT_IDS=$(jq -r '.[] | select(.user.login=="github-actions[bot]") | .id' comments.json)
+          for COMMENT_ID in $COMMENT_IDS; do
+            echo "Deleting comment ID $COMMENT_ID"
+            curl -s -X DELETE -H "Accept: application/vnd.github.v3+json" \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID"
+          done
+      - name: Script to comment on PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🎉 This PR is included in version ${{ steps.next_version.outputs.NEXT_TAG }} 🎉 '
+            })

--- a/.github/workflows/expected-release-version.yml
+++ b/.github/workflows/expected-release-version.yml
@@ -50,7 +50,11 @@ jobs:
         run: |
           echo ${{ steps.get-latest-tag.outputs.tag }}
           IFS='v' read -r -a VERSION <<< "${{ steps.get-latest-tag.outputs.tag }}"
-          IFS='.' read -r -a VERSION_PARTS <<< "${VERSION[1]}"
+          if [ VERSION[1] == null ]: then
+            IFS='.' read -r -a VERSION_PARTS <<< "${VERSION[0]}"
+          elif [ VERSION[1] != null ]: then
+            IFS='.' read -r -a VERSION_PARTS <<< "${VERSION[1]}"
+          fi
           MAJOR=${VERSION_PARTS[0]}
           MINOR=${VERSION_PARTS[1]}
           PATCH=${VERSION_PARTS[2]}


### PR DESCRIPTION
### Description
Semantic release was being used to comment the release version upon merging the PR. We needed to know the expected version of the release prior to merging. This PR adds the workflow to comment the expected release version. 

### Ticket Link
https://github.com/openedx/wg-frontend/issues/139

### Test
Tested the workflow on following PR 
https://github.com/edx/frontend-component-header-edx/pull/586