### PR TITLE
build: Switch to ubuntu-latest for builds

### DIFF
--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -62,7 +62,7 @@ on:
 jobs:
 
   repos_list:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     outputs:
       output1: ${{ steps.repos_list.outputs.list }}
@@ -74,7 +74,7 @@ jobs:
         echo "::set-output name=list::[${{github.event.inputs.repos_list}}]"
 
   bulk_update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ repos_list ]
     strategy:
       fail-fast: false

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   commitlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   version-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lockfileversion-check-v3.yml
+++ b/.github/workflows/lockfileversion-check-v3.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   version-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   version-check:
-    runs-on:  ubuntu-20.04
+    runs-on:  ubuntu-latest
     outputs:
       output1: ${{ steps.getversion.outputs.version }}
     steps:

--- a/.github/workflows/merge-python-requirements-upgrade-prs.yml
+++ b/.github/workflows/merge-python-requirements-upgrade-prs.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   get_list_of_prs:
     name: Get list of PRs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       urls: ${{ steps.generate_urls.outputs.urls }}
     steps:
@@ -62,7 +62,7 @@ jobs:
           
 
   merge_pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - get_list_of_prs
     if: needs.get_list_of_prs.outputs.urls != '[]' # Skip if there are no URLs found

--- a/.github/workflows/repo-health-job.yml
+++ b/.github/workflows/repo-health-job.yml
@@ -56,7 +56,7 @@ on:
 
 jobs:
   repo_health_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   upgrade_requirements:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: setup target branch


### PR DESCRIPTION
This code does not have any dependencies that are specific to any specific
version of ubuntu.  So instead of testing on a specific version and then needing
to do work to keep the versions up-to-date, we switch to the ubuntu-latest
target which should be sufficient for testing purposes.

This work is being done as a part of https://github.com/openedx/platform-roadmap/issues/377

closes https://github.com/openedx/.github/issues/149
