### PR TITLE
fix: refactor update-browserslist-db to auto-approve PR and auto-merge with `gh` CLI

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -34,13 +34,13 @@ jobs:
             Updated browserslist DB
           branch: update-browserslist-db
 
-    - name: Auto-Approve the Pull Request
-      uses: hmarr/auto-approve-action@v3
-      with:
-        github-token: ${{ secrets.requirements_bot_github_token }}
-        pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+    - name: Auto-approve Pull Request
+      if: steps.cpr.outputs.pull-request-operation == 'created'
+      run: gh pr review --approve "${{ steps.cpr.outputs.pull-request-number }}"
+      env:
+        GH_TOKEN: ${{ secrets.requirements_bot_github_token }}
 
     - name: Enable Pull Request Automerge
-      run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
+      run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
       env:
-        GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}
+        GH_TOKEN: ${{ secrets.requirements_bot_github_token }}

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -8,27 +8,19 @@ on:
 jobs:
   update-dep:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [16]
-        npm: [8.5.x]
-
     steps:
-    - name: Check out the repo
+    - name: Checkout the repo
       uses: actions/checkout@v4
-      
-    - name: Install node
+
+    - name: Install Node
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node }}
-    
-    - name: Install dependencies
-      run: npm install -g npm@${{ matrix.npm }}
+        node-version-file: '.nvmrc'
 
-    - name: Install Packages 
+    - name: Install Dependencies
       run: npm ci
 
-    - name: Update dependencies
+    - name: Update browserslist DB
       run: npx update-browserslist-db@latest
 
     - name: Create Pull Request
@@ -42,10 +34,13 @@ jobs:
             Updated browserslist DB
           branch: update-browserslist-db
 
-    - name: Enable Pull Request Automerge
-      if: steps.cpr.outputs.pull-request-operation == 'created'
-      uses: peter-evans/enable-pull-request-automerge@v2
+    - name: Auto-Approve the Pull Request
+      uses: hmarr/auto-approve-action@v3
       with:
-        token: ${{ secrets.requirements_bot_github_token }}
+        github-token: ${{ secrets.requirements_bot_github_token }}
         pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-        merge-method: squash
+
+    - name: Enable Pull Request Automerge
+      run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}


### PR DESCRIPTION
The existing `update-browserslist-db` GitHub Action workflow file (often used by Open edX's shared JS libraries and MFEs) is not properly auto-merging, which results in stale data consumed by `browserslist`. I believe this is largely due to the lack of auto-approving the generated PR, which prevents it from passing branch protections on default branches.

This PR updates the workflow file as follows:
* No longer runs Node 16, instead relying on `.nvmrc` files defined in the consuming repo.
* Added a step to auto-approve the generated pull request (previously not included; not sure if the auto-merge ever really worked as a result?).
* Replaces the previous auto-merge step to instead rely on the `gh` CLI directly, per the documentation in `peter-evans/enable-pull-request-automerge` ([see README](https://github.com/peter-evans/enable-pull-request-automerge)).