### PR TITLE
fix: only enable automerge when PR is created in `update-browserslist-db`

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -41,6 +41,7 @@ jobs:
         GH_TOKEN: ${{ secrets.requirements_bot_github_token }}
 
     - name: Enable Pull Request Automerge
+      if: steps.cpr.outputs.pull-request-operation == 'created'
       run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
       env:
         GH_TOKEN: ${{ secrets.requirements_bot_github_token }}


### PR DESCRIPTION
On a run of the recent changes to `update-browserslist-db`, it was [observed](https://github.com/openedx/frontend-app-admin-portal/actions/runs/12639940401/job/35219310415) that when no diff is created when updating the `browserslist` DB, we correctly skip the "auto-approve" step, but still attempt to run the "enable auto-merge" step, resulting in an error as there is not a valid PR number generated without a diff.

Note: this no diff case will occur any time the workflow is run without any changes the `browserslist` DB (e.g., on consecutive runs).