### PR TITLE
fix: update commitlint workflow to check for and download config as `.mjs`

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,9 +23,9 @@ jobs:
 
       - name: Download a local configuration file if needed
         run: |
-          if [[ ! -f commitlint.config.js ]] && [[ ! -f commitlint.config.cjs ]]; then
+          if [[ ! -f commitlint.config.mjs ]]; then
             echo "Downloading the default commitlint config from edx_lint"
-            wget --no-verbose -O commitlint.config.cjs https://raw.githubusercontent.com/openedx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
+            wget --no-verbose -O commitlint.config.mjs https://raw.githubusercontent.com/openedx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
           fi
 
       - name: Run commitlint


### PR DESCRIPTION
### What this does

Fixes the workflow piece of https://github.com/openedx/.github/issues/163

### Why is this a draft?

If this lands before https://github.com/openedx/edx-lint/pull/486 it will break things. Once that lands I will move this out of draft.