### PR TITLE
fix: update github DEPR issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -20,7 +20,7 @@ body:
     id: accept-date
     attributes:
       label: Target Plan Accepted Date
-      description: When is the target date for getting the proposal reviewed and accepted? A good default is approximately 2 weeks from when the RFC is communicated (see [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html)).
+      description: When is the target date for getting the proposal reviewed and accepted? A good default is approximately 2 weeks from the RFC Start Date (see [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html)).
       placeholder: "2025-01-29"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -12,7 +12,7 @@ body:
     id: rfc-start-date
     attributes:
       label: RFC Start Date
-      description: The start date of the RFC (possibly today)
+      description: The start date of the RFC (Request for Comments). Use the day you will announce this DEPR ticket on discourse (possibly today).
       placeholder: "2025-01-15"
     validations:
       required: true
@@ -28,7 +28,7 @@ body:
     id: transition-unblocked-date
     attributes:
       label: Target Transition Unblocked Date
-      description: When is the target date for having a replacement ready, and unblocking operators for preparing for the final breaking change?
+      description: When is the target date for having a replacement ready, and unblocking operators for preparing for the final breaking change? See [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html) for more details.
       placeholder: "2025-03-15"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -46,10 +46,10 @@ body:
       label: Earliest Open edX Named Release with Breaking Changes
       description: What is the earliest named release without the breaking changes? Choose the first release cut date after the Earliest Breaking Changes Unblocked Date. Approximate dates are listed below; for exact dates, see the [release schedule](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3613392957/Open+edX+Release+Schedule) or reach out to the Build Test Release working group (#wg-build-test-release in Slack).
       options:
-       - Ulmo - 2025-10
-       - Verawood - 2026-04
-       - W - 2026-10
-       - X - 2027-04
+        - Ulmo - 2025-10
+        - Verawood - 2026-04
+        - W - 2026-10
+        - X - 2027-04
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -9,27 +9,43 @@ body:
         Refer to [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html) for more detail on the deprecation and removal process. This ticket should only be used for proposing the removal of an Open edX technology.
         Please leave [DEPR] in the title of your ticket!
   - type: input
-    id: todays-date
+    id: rfc-start-date
     attributes:
-      label: Proposal Date
-      description: The start date of this proposal (likely today)
-      placeholder: "2024-01-15"
+      label: RFC Start Date
+      description: The start date of the RFC (possibly today)
+      placeholder: "2025-01-15"
     validations:
       required: true
   - type: input
     id: accept-date
     attributes:
-      label: Target Ticket Acceptance Date
-      description: When is the target date for getting this proposal reviewed and accepted? A good default is approximately 2 weeks from when the ticket is communicated (see [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html)).
-      placeholder: "2024-01-29"
+      label: Target Plan Accepted Date
+      description: When is the target date for getting the proposal reviewed and accepted? A good default is approximately 2 weeks from when the RFC is communicated (see [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html)).
+      placeholder: "2025-01-29"
+    validations:
+      required: true
+  - type: input
+    id: transition-unblocked-date
+    attributes:
+      label: Target Transition Unblocked Date
+      description: When is the target date for having a replacement ready, and unblocking operators for preparing for the final breaking change?
+      placeholder: "2025-03-15"
+    validations:
+      required: true
+  - type: input
+    id: breaking-change-unblocked-date
+    attributes:
+      label: Earliest Breaking Changes Unblocked Date
+      description: When is the earliest date you may make breaking changes? A good default is the later of 6 months after the RFC Start Date, or 1 month after the Target Transition Unblocked Date. This date can be negotiated as part of the RFC process. 
+      placeholder: "2025-07-15"
     validations:
       required: true
   - type: input
     id: named-release-without
     attributes:
-      label: Earliest Open edX Named Release Without This Functionality
-      description: What is the earliest named release without this code? Named releases are generally CUT in early April and early October. Use "Redwood - 2024-04", or "Sumac - 2024-10", or "Teak - 2025-04" as examples. Please reach out to the Build Test Release working group (#wg-build-test-release in Slack) if you're not sure.
-      placeholder: "Redwood - 2024-04"
+      label: Earliest Open edX Named Release with Breaking Changes
+      description: What is the earliest named release without the breaking changes? Choose the first release cut date after the Earliest Breaking Changes Unblocked Date. Named releases are generally CUT in early April and early October. Use "Ulmo - 2025-10", "Verawood - 2026-04" as examples. Please reach out to the Build Test Release working group (#wg-build-test-release in Slack) if you're not sure.
+      placeholder: "Ulmo - 2025-10"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -46,10 +46,10 @@ body:
       label: Earliest Open edX Named Release with Breaking Changes
       description: What is the earliest named release without the breaking changes? Choose the first release cut date after the Earliest Breaking Changes Unblocked Date. Approximate dates are listed below; for exact dates, see the [release schedule](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3613392957/Open+edX+Release+Schedule) or reach out to the Build Test Release working group (#wg-build-test-release in Slack).
       options:
-        - Ulmo - 2025-10
-        - Verawood - 2026-04
-        - W - 2026-10
-        - X - 2027-04
+        - "Ulmo - 2025-10"
+        - "Verawood - 2026-04"
+        - "W - 2026-10"
+        - "X - 2027-04"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -44,8 +44,12 @@ body:
     id: named-release-without
     attributes:
       label: Earliest Open edX Named Release with Breaking Changes
-      description: What is the earliest named release without the breaking changes? Choose the first release cut date after the Earliest Breaking Changes Unblocked Date. Named releases are generally CUT in early April and early October. Use "Ulmo - 2025-10", "Verawood - 2026-04" as examples. Please reach out to the Build Test Release working group (#wg-build-test-release in Slack) if you're not sure.
-      placeholder: "Ulmo - 2025-10"
+      description: What is the earliest named release without the breaking changes? Choose the first release cut date after the Earliest Breaking Changes Unblocked Date. Approximate dates are listed below; for exact dates, see the [release schedule](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3613392957/Open+edX+Release+Schedule) or reach out to the Build Test Release working group (#wg-build-test-release in Slack).
+      options:
+       - Ulmo - 2025-10
+       - Verawood - 2026-04
+       - W - 2026-10
+       - X - 2027-04
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -36,7 +36,7 @@ body:
     id: breaking-change-unblocked-date
     attributes:
       label: Earliest Breaking Changes Unblocked Date
-      description: When is the earliest date you may make breaking changes? A good default is the later of 6 months after the RFC Start Date, or 1 month after the Target Transition Unblocked Date. This date can be negotiated as part of the RFC process. 
+      description: When is the earliest date you may make breaking changes? A good default is the later of 6 months after the RFC Start Date, or 1 month after the Target Transition Unblocked Date. This date can be negotiated as part of the RFC process. See [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html) for more details.
       placeholder: "2025-07-15"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -40,16 +40,17 @@ body:
       placeholder: "2025-07-15"
     validations:
       required: true
-  - type: input
+  - type: dropdown
     id: named-release-without
     attributes:
       label: Earliest Open edX Named Release with Breaking Changes
       description: What is the earliest named release without the breaking changes? Choose the first release cut date after the Earliest Breaking Changes Unblocked Date. Approximate dates are listed below; for exact dates, see the [release schedule](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3613392957/Open+edX+Release+Schedule) or reach out to the Build Test Release working group (#wg-build-test-release in Slack).
       options:
-        - "Ulmo - 2025-10"
-        - "Verawood - 2026-04"
-        - "W - 2026-10"
-        - "X - 2027-04"
+        - Ulmo - 2025-10
+        - Verawood - 2026-04
+        - W - 2026-10
+        - X - 2027-04
+        - Y - 2027-10
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Updated DEPR issue template dates to better
reflect the updated timeline recommendations
in OEP-21 for DEPR.

See https://github.com/openedx/open-edx-proposals/blame/master/oeps/processes/oep-0021-proc-deprecation.rst#L207-L218

These are dates in the current template:
- Proposal Date
- Target Ticket Acceptance Date
- Earliest Open edX Named Release Without This Functionality

Here are some proposed replacements:
- RFC Start Date
- Target Plan Accepted Date
- Target Transition Unblocked Date
- Earliest Breaking Changes Unblocked Date
- Earliest Open edX Named Release with Breaking Changes