### PR TITLE
feat: Action to add an issue or PR to a CC board

### DIFF
--- a/.github/workflows/add-to-cc-board.yml
+++ b/.github/workflows/add-to-cc-board.yml
@@ -40,6 +40,7 @@ jobs:
               ;;
             *)
               echo "Unknown board name: '${{ inputs.board_name }}'" >&2
+              echo "Valid board names: cc-edx-platform, cc-frontend-apps, cc-core-apps, cc-other-utils" >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/add-to-cc-board.yml
+++ b/.github/workflows/add-to-cc-board.yml
@@ -1,0 +1,51 @@
+name: Add Issue or PR to a Core Contributor project board
+on:
+  workflow_call:
+    inputs:
+      board_name:
+        required: true
+        type: string
+    secrets:
+      projects_access_token:
+        required: true
+
+jobs:
+  add-item:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set item URL
+        id: set_item_url
+        run: |
+          if [[ "${{ github.event.issue.html_url }}" != "" ]]; then
+            echo "item_url=${{ github.event.issue.html_url }}" >> $GITHUB_OUTPUT
+          else
+            echo "item_url=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Map board name to board URL
+        id: map_board
+        run: |
+          case "${{ inputs.board_name }}" in
+            cc-edx-platform)
+              echo "project_number=79" >> $GITHUB_OUTPUT
+              ;;
+            cc-frontend-apps)
+              echo "project_number=80" >> $GITHUB_OUTPUT
+              ;;
+            cc-core-apps)
+              echo "project_number=81" >> $GITHUB_OUTPUT
+              ;;
+            cc-other-utils)
+              echo "project_number=82" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "Unknown board name: '${{ inputs.board_name }}'" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Add item to board
+        run: |
+          gh project item-add ${{ steps.map_board.outputs.project_number }} --owner openedx --url ${{ steps.set_item_url.outputs.item_url }}
+        env:
+          GH_TOKEN: ${{ secrets.projects_access_token }}


### PR DESCRIPTION
## Description

This PR adds the action to add an issue or PR to a CC board. This is a reusable action. Follows the 
[technical discovery](https://docs.google.com/document/d/1uCfu-hyDG7U_dL9E3LTO7R560_eGya03M4MVMZHwH3c/edit?tab=t.0#heading=h.ibtgcqo5je5q) with some changes:

- We avoided using an external file to retrieve the board. We used a variable in the action to specify the board, and we placed the board numbers in the action. This was because it was very complicated to read a file in a reusable action.
- A token with the `projects` scope is required, the `GITHUB_TOKEN` does not have this scope

## Supporting information

- Github issue: https://github.com/openedx/wg-coordination/issues/157
- Technical discovery: https://docs.google.com/document/d/1uCfu-hyDG7U_dL9E3LTO7R560_eGya03M4MVMZHwH3c/edit?usp=sharing
- Internal ticket: [SE-6444](https://tasks.opencraft.com/browse/SE-6444)

## Testing instructions

- You can see/test this action working on this sandbox repo:
    - [repo-edx](https://github.com/ChrisChV-Sandbox-Organization/repo-edx)
    - [.github sandbox](https://github.com/ChrisChV-Sandbox-Organization/.github)
    - [Board](https://github.com/orgs/ChrisChV-Sandbox-Organization/projects/1/views/1)

## Other notes

- Create the action caller (like [this](https://github.com/ChrisChV-Sandbox-Organization/repo-edx/blob/main/.github/workflows/add-to-cc-board.yml)) on each repo, starting with `edx-platform`
- Create documentation about creating the action caller on repos.
