### PR TITLE
docs: Add more instructions to the Fast-Track DEPR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/depr-ticket-fast-track.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket-fast-track.yml
@@ -6,16 +6,40 @@ body:
   - type: markdown
     attributes:
       value: |
-        This announces a pre-approved breaking change. These include planned upgrade tasks, removal of unreachable code, and subtasks of other approved DEPR tickets. Consult the DEPR Working Group if unsure.
+        Use this template to announce a pre-accepted breaking change. These include planned upgrade tasks, removal of unreachable code, and subtasks of other accepted DEPR tickets. 
         
-        The standard DEPR process is described in [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html). This ticket is using the new ["Fast Track" Process]((https://github.com/openedx/.github/issues/175)), which means it will skip the Request-For-Comments (RFC) stages and move right to "Transition Unblocked."
+        The standard DEPR process is described in [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html). This ticket is using the new ["Fast Track" process]((https://github.com/openedx/.github/issues/175)), which means it gets to skip the RFC (Request for Comments) period. After creating an issue using this template, you do not need to make forum post announcing the RFC period. Instead, **update the issue's status to "Transition Unblocked", and paste the issue link in `#cc-risky-changes` in order to warn site operators.** Once your chosen Breaking Change Unblocked date has passed, you are clear to make the breaking change.
       
         Please leave [DEPR] in the title of your ticket!
+  - type: input
+    id: rfc-start-date
+    attributes:
+      label: RFC Start Date
+      description: Fast-Track Deprecations do not have a comment period. **Leave this unchanged!**
+      value: N/A -- Already Accepted
+    validations:
+      required: true
+  - type: input
+    id: accept-date
+    attributes:
+      label: Target Plan Accepted Date
+      description: Fast-Track Deprecations are pre-Accepted. **Leave this unchanged!**
+      value: N/A -- Already Accepted
+    validations:
+      required: true
+  - type: input
+    id: transition-unblocked-date
+    attributes:
+      label: Target Transition Unblocked Date
+      description: When can operators prepare for the breaking change? For Fast-Track Deprecations, this generally should be "Immediately". **If not, please specify.**
+      value: "Immediately -- Transition Already Unblocked"
+    validations:
+      required: true
   - type: input
     id: breaking-change-unblocked-date
     attributes:
       label: Earliest Breaking Changes Unblocked Date
-      description: When is the earliest date you may make breaking changes? A good default is 2 weeks from today, giving operators time to transition.
+      description: When is the earliest date you may make breaking changes? A good default is 2 weeks from the Transition Unblocked Date, giving operators time to transition.
       placeholder: "2025-01-14"
     validations:
       required: true


### PR DESCRIPTION
Eventually, we update use the GitHub workflow to recognize Fast-Track DEPR issues and apply the correct status & notification routing. In the meantime, though, we're just adding more instructions here so that contributors can follow the process themselves.

Additionally, we add some default values to the Dates fields in order to make it clear what's going on in relation to the standard DEPR process.
These values could be used in the future as keyphrases to trigger the right GitHub workflow jobs.

Preview: https://github.com/openedx/.github/blob/kdmccormick/fast-track-2/.github/ISSUE_TEMPLATE/depr-ticket-fast-track.yml