### PR TITLE
fix: fix the upgrade workflow for forks

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -125,8 +125,8 @@ jobs:
           branch: "upgrade-python-requirements"
           branch-suffix: short-commit-hash
           add-paths: |
-            requirements
-            scripts/**/requirements*
+            requirements*
+            **/requirements*
           commit-message: |
             chore: Upgrade Python requirements
 


### PR DESCRIPTION
## Description
- The `requirements-upgrade-workflow` was updated to also run for forks as well
- It was tested against `edx-platform` fork which was successful
- This contained a requirement path specific to `edx-platform` which caused the workflow to fail for other forks with the following error 
```
  Uncommitted changes found. Adding a commit.
  /usr/bin/git add -- requirements scripts/**/requirements*
  fatal: pathspec 'scripts/**/requirements*' did not match any files
```

## Fix
- Updated the `scripts/**/requirements*` path to `**/requirements*` instead to make it generic 
- Now, it should be working for all the forks without the failure. 