### PR TITLE
fix: make upgrade workflow compatible to platform requirements

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -93,6 +93,18 @@ jobs:
           cd $GITHUB_WORKSPACE
           make upgrade
 
+      - name: prepare add-paths for PR
+        run: |
+          ADD_PATHS="requirements"
+          
+          if [ -d "scripts" ]; then
+            ADD_PATHS="${ADD_PATHS}"$'\nscripts/**/requirements*'
+          
+          # Set the environment variable for use in subsequent steps
+          echo "ADD_PATHS<<EOF" >> $GITHUB_ENV
+          echo "$ADD_PATHS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
       - name: setup pull_request_creator
         if: ${{ env.is_fork == 'false' }}
         run: |
@@ -124,9 +136,7 @@ jobs:
         with:
           branch: "upgrade-python-requirements"
           branch-suffix: short-commit-hash
-          add-paths: |
-            requirements*
-            **/requirements*
+          add-paths: ${{ env.ADD_PATHS }}
           commit-message: |
             chore: Upgrade Python requirements
 


### PR DESCRIPTION
## Description
- The path in workflow was updated from `scripts/**/requirements*` to `**/requirements*` in the hopes that a generic pattern will work but it still generated following error when trying to add paths because the path was not available
```
  Uncommitted changes found. Adding a commit.
  /usr/bin/git add -- requirements* **/requirements*
  fatal: pathspec '**/requirements*' did not match any files
```

## Changes
- Now the workflow has been updated to dynamically add the `scripts` path in requirements only if the `scripts` path exists in the repo.
- This should now be compatible with `edx-platform` forks and forks of other repositories.