### PR TITLE
fix: Update contribution guidelines link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in contributing to the Open edX project!
 
-You can find our [latest contribution guidelines on the community wiki](https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+start+contributing+to+the+Open+edX+code+base).
+You can find our [latest contribution guidelines on the community wiki](https://docs.openedx.org/en/latest/developers/quickstarts/so_you_want_to_contribute.html).


### PR DESCRIPTION
Previously this was linking to a page that was removed and linking to the new destination.