### PR TITLE
fix: expose scoped read-only GITHUB_TOKEN in bulk_repo_update run script step

### DIFF
--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -75,6 +75,8 @@ jobs:
   bulk_update:
     runs-on: ubuntu-latest
     needs: [ repos_list ]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +109,8 @@ jobs:
         run: pip install ${{ github.event.inputs.packages }}
 
       - name: run script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ${{ github.event.inputs.script }}
 
       - name: setup pull_request_creator

--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -88,6 +88,7 @@ jobs:
             repository: ${{ github.event.inputs.organization}}/${{ matrix.repos }}
             token: ${{ secrets.requirements_bot_github_token }}
             fetch-depth: 0
+            persist-credentials: false
 
       - name: Get Default Branch of checkedout repo
         run: |


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to the `bulk_update` job, scoping the auto-generated `GITHUB_TOKEN` to read-only
- Exposes that scoped `GITHUB_TOKEN` (not the bot token) to the `run script` step via `env:`
- Allows scripts that call the GitHub API (e.g. `pinact` for SHA resolution) to authenticate without requiring the high-privilege bot token

## Context

Part of the org-wide GitHub Actions SHA-pinning migration: #165

The immediate use case is running `pinact run` via this workflow to bulk-pin all `uses:` action refs to full commit SHAs across openedx repos. `pinact` requires a GitHub token to resolve tags → SHAs via the API — read-only access is sufficient for this.

**Security note:** Reviewers flagged that passing `secrets.requirements_bot_github_token` (a high-privilege org-wide bot token) into the freeform `run script` step was too broad — it would give any dispatch caller full bot token privileges over arbitrary script execution. The safer approach is to use the auto-generated `GITHUB_TOKEN` scoped to `contents: read`. The bot token remains only in the `actions/checkout` and `create pull request` steps where elevated access is genuinely needed.

## Test plan

- [ ] Trigger `bulk_repo_update.yml` on a single test repo with `script: pinact run` after merging — confirm pinact resolves SHAs without auth errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)