### PR TITLE
chore: pin GitHub Actions workflows to full commit SHAs

### DIFF
--- a/.github/workflows/add-depr-ticket-to-depr-board.yml
+++ b/.github/workflows/add-depr-ticket-to-depr-board.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ (contains(github.event.issue.title, '[DEPR]') || startsWith(github.event.issue.body, 'Proposal Date')) && !contains(github.event.issue.labels.*.name, 'DEPR') }}
     steps:
       - name: apply DEPR label
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: DEPR
 
@@ -46,7 +46,7 @@ jobs:
       # are defined at the org level
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.GITHUB_APP_ID }}
           private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Alert in Slack
         id: slack
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token:  ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/add-issue-to-a-project.yml
+++ b/.github/workflows/add-issue-to-a-project.yml
@@ -29,13 +29,13 @@ jobs:
       # are defined at the org level
       - name: "Generate token"
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.GITHUB_APP_ID }}
           private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
 
       - name: "Add to project"
-        uses: actions/add-to-project@v2.0.0
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/${{ inputs.ORGANIZATION }}/projects/${{ inputs.PROJECT_NUMBER }}
           github-token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/add-issue-to-btr-project.yml
+++ b/.github/workflows/add-issue-to-btr-project.yml
@@ -35,6 +35,6 @@ jobs:
     if: github.event.label.name == 'release testing' && !contains(github.event.issue.labels.*.name, 'needs triage')
     steps:
       - name: Apply needs triage label
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: needs triage

--- a/.github/workflows/add-remove-label-on-comment.yml
+++ b/.github/workflows/add-remove-label-on-comment.yml
@@ -32,7 +32,7 @@ jobs:
           echo 'LABEL='$LABEL >> $GITHUB_ENV
 
       - name: apply label
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: ${{ env.LABEL }}
 
@@ -66,6 +66,6 @@ jobs:
           echo 'LABEL='$LABEL >> $GITHUB_ENV
 
       - name: remove label
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         with:
           labels: ${{ env.LABEL }}

--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -83,7 +83,7 @@ jobs:
         repos: ${{fromJson(needs.repos_list.outputs.output1)}}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
             repository: ${{ github.event.inputs.organization}}/${{ matrix.repos }}
             token: ${{ secrets.requirements_bot_github_token }}
@@ -96,12 +96,12 @@ jobs:
           echo "BRANCH=$branch" >> $GITHUB_ENV
 
       - name: setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ github.event.inputs.python_version }}
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 16
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Fetch 100 commits.  Should be enough?
           fetch-depth: 100
@@ -29,4 +29,4 @@ jobs:
           fi
 
       - name: Run commitlint
-        uses: wagoid/commitlint-github-action@v6
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/.github/workflows/lockfile-check-v20.yml
+++ b/.github/workflows/lockfile-check-v20.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Read Node.js version from .nvmrc
         id: read-nvmrc
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Retrieve version
         id: getversion
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 18
 

--- a/.github/workflows/lockfileversion-check-v3.yml
+++ b/.github/workflows/lockfileversion-check-v3.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Retrieve version
         id: getversion

--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -14,7 +14,7 @@ jobs:
       output1: ${{ steps.getversion.outputs.version }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Retrieve version
       id: getversion

--- a/.github/workflows/merge-python-requirements-upgrade-prs.yml
+++ b/.github/workflows/merge-python-requirements-upgrade-prs.yml
@@ -35,12 +35,12 @@ jobs:
       urls: ${{ steps.generate_urls.outputs.urls }}
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: pip install requests
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/repo-health-job.yml
+++ b/.github/workflows/repo-health-job.yml
@@ -89,15 +89,15 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Clone edx-repo-health repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: openedx/edx-repo-health
           path: edx-repo-health
@@ -109,21 +109,21 @@ jobs:
           python3 -m pip install -r edx-repo-health/requirements/pip-tools.txt
 
       - name: Clone testeng-ci repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: openedx/testeng-ci
           path: testeng-ci
           ref: "master"
 
       - name: Clone repo-tools repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: openedx/repo-tools
           path: repo_tools
           ref: master
 
       - name: Clone repo-health-data repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.TARGET_REPO_TO_STORE_REPORTS }}
           path: repo-health-data
@@ -167,13 +167,13 @@ jobs:
 
       - name: Upload sqlite db as artifact
         if: ${{ inputs.DASHBOARD_NAME == 'repo_health' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sqlite db artifact
           path: dashboards/dashboard.sqlite3
 
       - name: Send email on failure
-        uses: dawidd6/action-send-mail@v17
+        uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
         if: ${{ failure() && inputs.ENABLE_EMAIL_ALERTS }}
         with:
           server_address: email-smtp.us-east-1.amazonaws.com
@@ -186,7 +186,7 @@ jobs:
           body: ${{ github.workflow }} in ${{ github.repository }} failed! For details, see https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Send email on success
-        uses: dawidd6/action-send-mail@v17
+        uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
         if: ${{ success() && inputs.ENABLE_EMAIL_ALERTS && inputs.ENABLE_EMAIL_ALERTS_ON_SUCCESS }}
         with:
           server_address: email-smtp.us-east-1.amazonaws.com

--- a/.github/workflows/self-assign-issue.yml
+++ b/.github/workflows/self-assign-issue.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.event.comment.body, 'assign me') }}
     steps:
-      - uses: actions-ecosystem/action-add-assignees@v1
+      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747 # v1.0.0
         with:
           github_token: ${{ secrets.github_token }}
           assignees: ${{ github.triggering_actor }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -83,7 +83,7 @@ jobs:
       run: sudo cp "shellcheck-${{ inputs.shellcheck-version }}/shellcheck" /usr/local/bin
 
     - name: (Setup) Check out repository branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build the command for finding shell scripts
       run: |

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: '.nvmrc'
 
@@ -25,7 +25,7 @@ jobs:
 
     - name: Create Pull Request
       id: cpr
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
           token: ${{ secrets.requirements_bot_github_token }}
           commit-message: 'chore: update browserslist DB'

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -75,12 +75,12 @@ jobs:
             echo "Using standard approach: bot token available"
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.target_branch }}
 
       - name: setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ inputs.python_version }}
       # With the updated package lxml>5.0, now the system dev packages are necessary
@@ -92,7 +92,7 @@ jobs:
 
       # As we begin to move repos to uv we need to install it
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -141,7 +141,7 @@ jobs:
       - name: create pull request (fork-friendly)
         if: ${{ env.is_fork == 'true' }}
         id: createpullrequest_fork
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: "upgrade-python-requirements"
           branch-suffix: short-commit-hash
@@ -159,7 +159,7 @@ jobs:
 
       - name: Send failure notification
         if: ${{ failure() && inputs.email_address && env.smtp_available == 'true' }}
-        uses: dawidd6/action-send-mail@v17
+        uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
         with:
           server_address: email-smtp.us-east-1.amazonaws.com
           server_port: 465
@@ -172,7 +172,7 @@ jobs:
 
       - name: Send success notification
         if: ${{ inputs.send_success_notification && inputs.email_address && steps.createpullrequest.outputs.generated_pr && env.smtp_available == 'true' }}
-        uses: dawidd6/action-send-mail@v17
+        uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
         with:
           server_address: email-smtp.us-east-1.amazonaws.com
           server_port: 465


### PR DESCRIPTION
Pins all `uses:` action refs to their full commit SHA with the version tag preserved as a comment. Part of org-wide SHA-pinning migration: openedx/.github#165